### PR TITLE
Fix a bug in C++ BigNum about Minus

### DIFF
--- a/模板/c++高精度.cpp
+++ b/模板/c++高精度.cpp
@@ -164,7 +164,7 @@ BigNum BigNum::operator-(const BigNum &T)const  //两个大数之间的相减运
         else t1.a[i]-=t2.a[i];
     }
     t1.len=big;
-    while(t1.a[len-1]==0 && t1.len>1)
+    while(t1.a[t1.len-1]==0 && t1.len>1)
     {
         t1.len--;
         big--;


### PR DESCRIPTION
There is a bug about c++高精度.cpp.
In BigNum operator-(const BigNum &)const
When you getover the prefix zero
